### PR TITLE
Add a Makefile for tests suite purposes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+build: 
+	Rscript -e "library(\"pak\");pak::local_install(dependencies=TRUE, ask=FALSE)"
+
+test: 
+	Rscript -e "library(\"devtools\");devtools::check()"
+
+clean:
+	Rscript -e "remove.packages(\"treepplr\")"


### PR DESCRIPTION
With this add we can automatically test the package with the rest of the treeppl suite.

You can directly build the package with `make build`, suppress it from your library with  `make clean` and launch the full devools check with  `make test`.

R tests are not passing right now.
